### PR TITLE
Changed the Dockerfile to use a specific node version 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:16.8
 EXPOSE 1234
 RUN apt-get update
 RUN apt-get install -y osmctools


### PR DESCRIPTION
Newer version of Node seem to have problems with sqlite. Setting to use the fixed node version (16.8) seems to allow building again